### PR TITLE
retirar inserção de short description

### DIFF
--- a/lib/store-api/new-product.js
+++ b/lib/store-api/new-product.js
@@ -62,9 +62,6 @@ module.exports = (produto) => {
   if (produto.descricaoCurta) {
     schema.body_html = produto.descricaoCurta
   }
-  if (produto.descricaoComplementar) {
-    schema.short_description = produto.descricaoComplementar.slice(0, 254)
-  }
   if (produto.imagem && produto.imagem.length) {
     schema.pictures = []
     produto.imagem.forEach(img => {


### PR DESCRIPTION
Uma vez que o bling envia um campo que lojistas nem utilizam, que seria a informação complementar, deixamos sem, quem quiser, insere manualmente