### PR TITLE
Inserir unidade de medida no peso

### DIFF
--- a/lib/store-api/new-product.js
+++ b/lib/store-api/new-product.js
@@ -13,7 +13,8 @@ module.exports = (produto) => {
   schema.cost_price = Number(produto.precoCusto)
   schema.body_text = produto.descricaoComplementar || ''
   schema.weight = {
-    value: parseFloat(produto.pesoBruto) || 0
+    value: parseFloat(produto.pesoBruto) || 0,
+    unit: 'kg'
   }
 
   schema.gtin = []


### PR DESCRIPTION
Uma vez que o bling permite mudar apenas unidade de comprimento e de peso continua sempre como kg, então foi alterado para setar já em kg