### PR TITLE
fix: callback number doesnt match

### DIFF
--- a/lib/bling/new-pedido.js
+++ b/lib/bling/new-pedido.js
@@ -85,6 +85,7 @@ const blingOrderSchema = order => {
   const pedido = {
     pedido: {
       numero: order.number,
+      numero_loja: order.number,
       vlr_frete: amount.freight || 0,
       vlr_desconto: amount.discount || 0,
       cliente,

--- a/routes/bling/webhook.js
+++ b/routes/bling/webhook.js
@@ -54,7 +54,7 @@ module.exports = (appSdk, database) => {
             const { sync } = configObj
             // update orders
             const trigger = retorno.pedidos[0].pedido
-            let resource = `/orders.json?number=${trigger.numero}` +
+            let resource = `/orders.json?number=${(trigger.numeroPedidoLoja || trigger.numero)}` +
               '&fields=_id,number,status,financial_status,fulfillment_status,shipping_lines' +
               ',buyers,items,hidden_metafields'
             const method = 'GET'


### PR DESCRIPTION
Se já existe um pedido no Bling, ele cria com outro número, logo ao fazer o callback, dará erro, porque não está batendo o pedido com mesmo número. Então seria necessário enviar o número do pedido em um parametro que não se modifica. Portanto, ao fazer o callback do pedido, pegaria o parâmetro que não se modifica e utilizaria ele para identificar o pedido na plus. Como existe já loja rodando, eu testo primeiro o parametro certo, se nao houver, pega o outro. Com o tempo, sempre terá o primeiro parametro, pois todos os novos pedidos serão com ele e os antigos já estaram despachados